### PR TITLE
add: setting to highlight edit lines

### DIFF
--- a/basic.vim
+++ b/basic.vim
@@ -7,8 +7,10 @@ set shiftwidth=4
 set clipboard+=unnamed
 set mouse=a
 set tabstop=4
-
 set backspace=indent,eol,start
+set cursorline
+hi clear CursorLine
+hi CursorLineNr term=bold cterm=NONE ctermfg=165 ctermbg=NONE
 
 if has('persistent_undo')
 	set undofile


### PR DESCRIPTION
Added a setting to highlight the line number being edited because it is difficult to see the cursor in WSL
![image](https://user-images.githubusercontent.com/30527257/69776638-6bf84280-11e0-11ea-8afc-c63482f7f274.png)
