### PR TITLE
add: process to get working directory

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -1,3 +1,4 @@
-source ~/github/vim-dotfiles/basic.vim
-source ~/github/vim-dotfiles/vimplug.vim
-source ~/github/vim-dotfiles/indent.vim
+let $WORK_DIR=getcwd()
+source $WORK_DIR/basic.vim
+source $WORK_DIR/vimplug.vim
+source $WORK_DIR/indent.vim


### PR DESCRIPTION
パスの指定が一部ベタ書きになっていたため、
`getcwd()`コマンドで.vimrcがあるディレクトリのフルパスを取得する処理を追加した。

Add processing to get full path of working directory include .vimrc.
Because depend environment.